### PR TITLE
[1.20.1] Improve mod compatibility in mixins, replacing most overwrites

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -173,9 +173,9 @@ dependencies {
          debug.export = true
     }
 
-    implementation(annotationProcessor("io.github.llamalad7:mixinextras-common:0.2.0-rc.5"))
-    implementation(jarJar("io.github.llamalad7:mixinextras-forge:0.2.0-rc.5")) {
-        jarJar.ranged(it, "[0.2.0-rc.5,)")
+    compileOnly(annotationProcessor("io.github.llamalad7:mixinextras-common:0.5.3"))
+    implementation(jarJar("io.github.llamalad7:mixinextras-forge:0.5.3")) {
+        jarJar.ranged(it, "[0.5.3,)")
     }
 
     // For more info...

--- a/src/main/java/com/Apothic0n/Astrological/mixin/ChorusFlowerBlockMixin.java
+++ b/src/main/java/com/Apothic0n/Astrological/mixin/ChorusFlowerBlockMixin.java
@@ -1,138 +1,39 @@
 package com.Apothic0n.Astrological.mixin;
 
 import com.Apothic0n.Astrological.core.objects.AstrologicalBlocks;
-import net.minecraft.core.BlockPos;
-import net.minecraft.core.Direction;
-import net.minecraft.server.level.ServerLevel;
-import net.minecraft.util.RandomSource;
-import net.minecraft.world.level.Level;
-import net.minecraft.world.level.LevelReader;
-import net.minecraft.world.level.block.Blocks;
+import com.llamalad7.mixinextras.expression.Definition;
+import com.llamalad7.mixinextras.expression.Expression;
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import com.llamalad7.mixinextras.sugar.Local;
+import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.ChorusFlowerBlock;
-import net.minecraft.world.level.block.ChorusPlantBlock;
 import net.minecraft.world.level.block.state.BlockState;
-import net.minecraft.world.level.block.state.properties.IntegerProperty;
-import org.jetbrains.annotations.Nullable;
-import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Overwrite;
-import org.spongepowered.asm.mixin.Shadow;
-@Mixin(value = ChorusFlowerBlock.class, priority = 69420)
+import org.spongepowered.asm.mixin.injection.At;
+
+@Mixin(ChorusFlowerBlock.class)
 public abstract class ChorusFlowerBlockMixin {
-
-    @Shadow @Final private ChorusPlantBlock plant;
-
-    @Shadow @Final public static IntegerProperty AGE;
-
-    @Shadow
-    private static boolean allNeighborsEmpty(LevelReader p_51698_, BlockPos p_51699_, @Nullable Direction p_51700_) {
-        return false;
+    @Definition(id = "blockstate", local = @Local(type = BlockState.class, ordinal = 1))
+    @Definition(id = "is", method = "Lnet/minecraft/world/level/block/state/BlockState;is(Lnet/minecraft/world/level/block/Block;)Z")
+    @Definition(id = "END_STONE", field = "Lnet/minecraft/world/level/block/Blocks;END_STONE:Lnet/minecraft/world/level/block/Block;")
+    @Expression("blockstate.is(END_STONE)")
+    @WrapOperation(method = "canSurvive", at = @At("MIXINEXTRAS:EXPRESSION"))
+    public boolean allowChorusFlowerOnPurpurite(BlockState instance, Block block, Operation<Boolean> original) {
+        return original.call(instance, block) || instance.is(AstrologicalBlocks.PURPURITE.get());
     }
 
-    @Shadow protected abstract void placeGrownFlower(Level p_51662_, BlockPos p_51663_, int p_51664_);
-
-    @Shadow protected abstract void placeDeadFlower(Level p_51659_, BlockPos p_51660_);
-
-    /**
-     * @author Apothicon
-     * @reason Allows chorus flowers to survive on purpurite.
-     */
-    @Overwrite
-    public boolean canSurvive(BlockState p_51683_, LevelReader p_51684_, BlockPos p_51685_) {
-        BlockState blockstate = p_51684_.getBlockState(p_51685_.below());
-        if (!blockstate.is(this.plant) && !blockstate.is(Blocks.END_STONE) && !blockstate.is(AstrologicalBlocks.PURPURITE.get())) {
-            if (!blockstate.isAir()) {
-                return false;
-            } else {
-                boolean flag = false;
-
-                for(Direction direction : Direction.Plane.HORIZONTAL) {
-                    BlockState blockstate1 = p_51684_.getBlockState(p_51685_.relative(direction));
-                    if (blockstate1.is(this.plant)) {
-                        if (flag) {
-                            return false;
-                        }
-
-                        flag = true;
-                    } else if (!blockstate1.isAir()) {
-                        return false;
-                    }
-                }
-
-                return flag;
-            }
-        } else {
-            return true;
-        }
-    }
-
-    /**
-     * @author Apothicon
-     * @reason Allows chorus flowers to connect to purpurite.
-     */
-    @Overwrite
-    public void randomTick(BlockState p_220980_, ServerLevel p_220981_, BlockPos p_220982_, RandomSource p_220983_) {
-        BlockPos blockpos = p_220982_.above();
-        if (p_220981_.isEmptyBlock(blockpos) && blockpos.getY() < p_220981_.getMaxBuildHeight()) {
-            int i = p_220980_.getValue(AGE);
-            if (i < 5 && net.minecraftforge.common.ForgeHooks.onCropsGrowPre(p_220981_, blockpos, p_220980_, true)) {
-                boolean flag = false;
-                boolean flag1 = false;
-                BlockState blockstate = p_220981_.getBlockState(p_220982_.below());
-                if (blockstate.is(Blocks.END_STONE) || blockstate.is(AstrologicalBlocks.PURPURITE.get())) {
-                    flag = true;
-                } else if (blockstate.is(this.plant)) {
-                    int j = 1;
-
-                    for(int k = 0; k < 4; ++k) {
-                        BlockState blockstate1 = p_220981_.getBlockState(p_220982_.below(j + 1));
-                        if (!blockstate1.is(this.plant)) {
-                            if (blockstate1.is(Blocks.END_STONE) || blockstate1.is(AstrologicalBlocks.PURPURITE.get())) {
-                                flag1 = true;
-                            }
-                            break;
-                        }
-
-                        ++j;
-                    }
-
-                    if (j < 2 || j <= p_220983_.nextInt(flag1 ? 5 : 4)) {
-                        flag = true;
-                    }
-                } else if (blockstate.isAir()) {
-                    flag = true;
-                }
-
-                if (flag && allNeighborsEmpty(p_220981_, blockpos, (Direction)null) && p_220981_.isEmptyBlock(p_220982_.above(2))) {
-                    p_220981_.setBlock(p_220982_, this.plant.getStateForPlacement(p_220981_, p_220982_), 2);
-                    this.placeGrownFlower(p_220981_, blockpos, i);
-                } else if (i < 4) {
-                    int l = p_220983_.nextInt(4);
-                    if (flag1) {
-                        ++l;
-                    }
-
-                    boolean flag2 = false;
-
-                    for(int i1 = 0; i1 < l; ++i1) {
-                        Direction direction = Direction.Plane.HORIZONTAL.getRandomDirection(p_220983_);
-                        BlockPos blockpos1 = p_220982_.relative(direction);
-                        if (p_220981_.isEmptyBlock(blockpos1) && p_220981_.isEmptyBlock(blockpos1.below()) && allNeighborsEmpty(p_220981_, blockpos1, direction.getOpposite())) {
-                            this.placeGrownFlower(p_220981_, blockpos1, i + 1);
-                            flag2 = true;
-                        }
-                    }
-
-                    if (flag2) {
-                        p_220981_.setBlock(p_220982_, this.plant.getStateForPlacement(p_220981_, p_220982_), 2);
-                    } else {
-                        this.placeDeadFlower(p_220981_, p_220982_);
-                    }
-                } else {
-                    this.placeDeadFlower(p_220981_, p_220982_);
-                }
-                net.minecraftforge.common.ForgeHooks.onCropsGrowPost(p_220981_, p_220982_, p_220980_);
-            }
-        }
+    @Definition(id = "blockstate", local = @Local(type = BlockState.class, ordinal = 1))
+    @Definition(id = "is", method = "Lnet/minecraft/world/level/block/state/BlockState;is(Lnet/minecraft/world/level/block/Block;)Z")
+    @Definition(id = "END_STONE", field = "Lnet/minecraft/world/level/block/Blocks;END_STONE:Lnet/minecraft/world/level/block/Block;")
+    @Definition(id = "blockstate1", local = @Local(type = BlockState.class, ordinal = 2))
+    @Expression(value = "blockstate.is(END_STONE)", id = "state1")
+    @Expression(value = "blockstate1.is(END_STONE)", id = "state2")
+    @WrapOperation(method = "randomTick", at = {
+            @At(value = "MIXINEXTRAS:EXPRESSION", id = "state1"),
+            @At(value = "MIXINEXTRAS:EXPRESSION", id = "state2")
+    })
+    public boolean allowChorusFlowerConnectToPurpurite(BlockState instance, Block block, Operation<Boolean> original) {
+        return original.call(instance, block) || instance.is(AstrologicalBlocks.PURPURITE.get());
     }
 }

--- a/src/main/java/com/Apothic0n/Astrological/mixin/ChorusPlantBlockMixin.java
+++ b/src/main/java/com/Apothic0n/Astrological/mixin/ChorusPlantBlockMixin.java
@@ -1,78 +1,71 @@
 package com.Apothic0n.Astrological.mixin;
 
 import com.Apothic0n.Astrological.core.objects.AstrologicalBlocks;
-import net.minecraft.core.BlockPos;
-import net.minecraft.core.Direction;
-import net.minecraft.world.level.BlockGetter;
-import net.minecraft.world.level.LevelAccessor;
-import net.minecraft.world.level.LevelReader;
-import net.minecraft.world.level.block.Blocks;
+import com.llamalad7.mixinextras.expression.Definition;
+import com.llamalad7.mixinextras.expression.Expression;
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import com.llamalad7.mixinextras.sugar.Local;
+import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.ChorusPlantBlock;
 import net.minecraft.world.level.block.PipeBlock;
 import net.minecraft.world.level.block.state.BlockState;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Overwrite;
-@Mixin(value = ChorusPlantBlock.class, priority = 69420)
+import org.spongepowered.asm.mixin.injection.At;
+
+@Mixin(ChorusPlantBlock.class)
 public abstract class ChorusPlantBlockMixin extends PipeBlock {
 
     public ChorusPlantBlockMixin(float p_55159_, Properties p_55160_) {
         super(p_55159_, p_55160_);
     }
 
-    /**
-     * @author Apothicon
-     * @reason Allows chorus plants to connect to purpurite.
-     */
-    @Overwrite
-    public BlockState getStateForPlacement(BlockGetter p_51711_, BlockPos p_51712_) {
-        BlockState blockstate = p_51711_.getBlockState(p_51712_.below());
-        BlockState blockstate1 = p_51711_.getBlockState(p_51712_.above());
-        BlockState blockstate2 = p_51711_.getBlockState(p_51712_.north());
-        BlockState blockstate3 = p_51711_.getBlockState(p_51712_.east());
-        BlockState blockstate4 = p_51711_.getBlockState(p_51712_.south());
-        BlockState blockstate5 = p_51711_.getBlockState(p_51712_.west());
-        return this.defaultBlockState().setValue(DOWN, Boolean.valueOf(blockstate.is(this) || blockstate.is(Blocks.CHORUS_FLOWER) || blockstate.is(Blocks.END_STONE) || blockstate.is(AstrologicalBlocks.PURPURITE.get()))).setValue(UP, Boolean.valueOf(blockstate1.is(this) || blockstate1.is(Blocks.CHORUS_FLOWER))).setValue(NORTH, Boolean.valueOf(blockstate2.is(this) || blockstate2.is(Blocks.CHORUS_FLOWER))).setValue(EAST, Boolean.valueOf(blockstate3.is(this) || blockstate3.is(Blocks.CHORUS_FLOWER))).setValue(SOUTH, Boolean.valueOf(blockstate4.is(this) || blockstate4.is(Blocks.CHORUS_FLOWER))).setValue(WEST, Boolean.valueOf(blockstate5.is(this) || blockstate5.is(Blocks.CHORUS_FLOWER)));
+    @Definition(id = "blockstate", local = @Local(type = BlockState.class, ordinal = 0))
+    @Definition(id = "blockstate1", local = @Local(type = BlockState.class, ordinal = 1))
+    @Definition(id = "blockstate2", local = @Local(type = BlockState.class, ordinal = 2))
+    @Definition(id = "blockstate3", local = @Local(type = BlockState.class, ordinal = 3))
+    @Definition(id = "blockstate4", local = @Local(type = BlockState.class, ordinal = 4))
+    @Definition(id = "blockstate5", local = @Local(type = BlockState.class, ordinal = 5))
+    @Definition(id = "is", method = "Lnet/minecraft/world/level/block/state/BlockState;is(Lnet/minecraft/world/level/block/Block;)Z")
+    @Definition(id = "CHORUS_FLOWER", field = "Lnet/minecraft/world/level/block/Blocks;CHORUS_FLOWER:Lnet/minecraft/world/level/block/Block;")
+    @Expression(value = "blockstate.is(CHORUS_FLOWER)", id = "state1")
+    @Expression(value = "blockstate1.is(CHORUS_FLOWER)", id = "state2")
+    @Expression(value = "blockstate2.is(CHORUS_FLOWER)", id = "state3")
+    @Expression(value = "blockstate3.is(CHORUS_FLOWER)", id = "state4")
+    @Expression(value = "blockstate4.is(CHORUS_FLOWER)", id = "state5")
+    @Expression(value = "blockstate5.is(CHORUS_FLOWER)", id = "state6")
+    @WrapOperation(method = "getStateForPlacement(Lnet/minecraft/world/level/BlockGetter;Lnet/minecraft/core/BlockPos;)Lnet/minecraft/world/level/block/state/BlockState;", at = {
+            @At(value = "MIXINEXTRAS:EXPRESSION", id = "state1"),
+            @At(value = "MIXINEXTRAS:EXPRESSION", id = "state2"),
+            @At(value = "MIXINEXTRAS:EXPRESSION", id = "state3"),
+            @At(value = "MIXINEXTRAS:EXPRESSION", id = "state4"),
+            @At(value = "MIXINEXTRAS:EXPRESSION", id = "state5"),
+            @At(value = "MIXINEXTRAS:EXPRESSION", id = "state6"),
+    })
+    private static boolean allowChorusPlantConnectToPurpurite(BlockState instance, Block block, Operation<Boolean> original) {
+        return original.call(instance, block) || instance.is(AstrologicalBlocks.PURPURITE.get());
     }
 
-    /**
-     * @author Apothicon
-     * @reason Allows chorus plants to connect to purpurite.
-     */
-    @Overwrite
-    public BlockState updateShape(BlockState p_51728_, Direction p_51729_, BlockState p_51730_, LevelAccessor p_51731_, BlockPos p_51732_, BlockPos p_51733_) {
-        if (!p_51728_.canSurvive(p_51731_, p_51732_)) {
-            p_51731_.scheduleTick(p_51732_, this, 1);
-            return super.updateShape(p_51728_, p_51729_, p_51730_, p_51731_, p_51732_, p_51733_);
-        } else {
-            boolean flag = p_51730_.is(this) || p_51730_.is(Blocks.CHORUS_FLOWER) || p_51729_ == Direction.DOWN && p_51730_.is(Blocks.END_STONE) || p_51729_ == Direction.DOWN && p_51730_.is(AstrologicalBlocks.PURPURITE.get());
-            return p_51728_.setValue(PROPERTY_BY_DIRECTION.get(p_51729_), Boolean.valueOf(flag));
-        }
+    @Definition(id = "state", local = @Local(type = BlockState.class, ordinal = 1, argsOnly = true))
+    @Definition(id = "is", method = "Lnet/minecraft/world/level/block/state/BlockState;is(Lnet/minecraft/world/level/block/Block;)Z")
+    @Definition(id = "END_STONE", field = "Lnet/minecraft/world/level/block/Blocks;END_STONE:Lnet/minecraft/world/level/block/Block;")
+    @Expression("state.is(END_STONE)")
+    @WrapOperation(method = "updateShape", at = @At("MIXINEXTRAS:EXPRESSION"))
+    public boolean allowChorusPlantUpdateShapeConnectToPurpurite(BlockState instance, Block block, Operation<Boolean> original) {
+        return original.call(instance, block) || instance.is(AstrologicalBlocks.PURPURITE.get());
     }
 
-    /**
-     * @author Apothicon
-     * @reason Allows chorus plants to survive on purpurite.
-     */
-    @Overwrite
-    public boolean canSurvive(BlockState p_51724_, LevelReader p_51725_, BlockPos p_51726_) {
-        BlockState blockstate = p_51725_.getBlockState(p_51726_.below());
-        boolean flag = !p_51725_.getBlockState(p_51726_.above()).isAir() && !blockstate.isAir();
-
-        for(Direction direction : Direction.Plane.HORIZONTAL) {
-            BlockPos blockpos = p_51726_.relative(direction);
-            BlockState blockstate1 = p_51725_.getBlockState(blockpos);
-            if (blockstate1.is(this)) {
-                if (flag) {
-                    return false;
-                }
-
-                BlockState blockstate2 = p_51725_.getBlockState(blockpos.below());
-                if (blockstate2.is(this) || blockstate2.is(Blocks.END_STONE) || blockstate2.is(AstrologicalBlocks.PURPURITE.get())) {
-                    return true;
-                }
-            }
-        }
-
-        return blockstate.is(this) || blockstate.is(Blocks.END_STONE) || blockstate.is(AstrologicalBlocks.PURPURITE.get());
+    @Definition(id = "blockstate", local = @Local(type = BlockState.class, ordinal = 1))
+    @Definition(id = "blockstate2", local = @Local(type = BlockState.class, ordinal = 3))
+    @Definition(id = "is", method = "Lnet/minecraft/world/level/block/state/BlockState;is(Lnet/minecraft/world/level/block/Block;)Z")
+    @Definition(id = "END_STONE", field = "Lnet/minecraft/world/level/block/Blocks;END_STONE:Lnet/minecraft/world/level/block/Block;")
+    @Expression(value = "blockstate2.is(END_STONE)", id = "state1")
+    @Expression(value = "blockstate.is(END_STONE)", id = "state2")
+    @WrapOperation(method = "canSurvive", at = {
+            @At(value = "MIXINEXTRAS:EXPRESSION", id = "state1"),
+            @At(value = "MIXINEXTRAS:EXPRESSION", id = "state2")
+    })
+    public boolean allowChorusPlantSurviveOnPurpurite(BlockState instance, Block block, Operation<Boolean> original) {
+        return original.call(instance, block) || instance.is(AstrologicalBlocks.PURPURITE.get());
     }
 }

--- a/src/main/java/com/Apothic0n/Astrological/mixin/ChorusPlantFeatureMixin.java
+++ b/src/main/java/com/Apothic0n/Astrological/mixin/ChorusPlantFeatureMixin.java
@@ -1,33 +1,19 @@
 package com.Apothic0n.Astrological.mixin;
 
 import com.Apothic0n.Astrological.core.objects.AstrologicalBlocks;
-import net.minecraft.core.BlockPos;
-import net.minecraft.util.RandomSource;
-import net.minecraft.world.level.WorldGenLevel;
-import net.minecraft.world.level.block.ChorusFlowerBlock;
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.levelgen.feature.ChorusPlantFeature;
-import net.minecraft.world.level.levelgen.feature.FeaturePlaceContext;
-import net.minecraft.world.level.levelgen.feature.configurations.NoneFeatureConfiguration;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 @Mixin(value = ChorusPlantFeature.class, priority = 69420)
 public class ChorusPlantFeatureMixin {
 
-    /**
-     * @author Apothicon
-     * @reason Allows chorus plants to generate on purpurite.
-     */
-    @Inject(at = @At("RETURN"), method = "place", cancellable = true)
-    private void placeOnPurpuriteToo(FeaturePlaceContext<NoneFeatureConfiguration> p_159521_, CallbackInfoReturnable<Boolean> cir) {
-        WorldGenLevel worldgenlevel = p_159521_.level();
-        BlockPos blockpos = p_159521_.origin();
-        RandomSource randomsource = p_159521_.random();
-        if (worldgenlevel.isEmptyBlock(blockpos) && worldgenlevel.getBlockState(blockpos.below()).is(AstrologicalBlocks.PURPURITE.get())) {
-            ChorusFlowerBlock.generatePlant(worldgenlevel, blockpos, randomsource, 8);
-            cir.setReturnValue(true);
-        }
+    @WrapOperation(method = "place", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/level/block/state/BlockState;is(Lnet/minecraft/world/level/block/Block;)Z"))
+    private boolean placeOnPurpuriteToo(BlockState instance, Block block, Operation<Boolean> original) {
+        return original.call(instance, block) || instance.is(AstrologicalBlocks.PURPURITE.get());
     }
 }

--- a/src/main/java/com/Apothic0n/Astrological/mixin/EndEffectsMixin.java
+++ b/src/main/java/com/Apothic0n/Astrological/mixin/EndEffectsMixin.java
@@ -4,28 +4,16 @@ import com.Apothic0n.Astrological.api.AstrologicalJsonReader;
 import net.minecraft.client.multiplayer.ClientLevel;
 import net.minecraft.client.renderer.DimensionSpecialEffects;
 import net.minecraft.world.level.Level;
-import net.minecraft.world.level.dimension.DimensionType;
 import net.minecraftforge.client.extensions.IForgeDimensionSpecialEffects;
 import org.joml.Vector3f;
-import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Overwrite;
-
-import java.awt.*;
+import org.spongepowered.asm.mixin.*;
 
 @Mixin(value = DimensionSpecialEffects.class, priority = 69420)
-public class DimensionSpecialEffectsMixin implements IForgeDimensionSpecialEffects {
+@Implements(@Interface(iface = IForgeDimensionSpecialEffects.class, prefix = "astrological$"))
+public class EndEffectsMixin implements IForgeDimensionSpecialEffects {
 
-    /**
-     * @author Apothicon
-     * @reason Removes hardcoded ambient lighting from the end.
-     */
-    @Overwrite
-    public boolean constantAmbientLight() {
-        return false;
-    }
-
-    @Override
-    public void adjustLightmapColors(ClientLevel level, float partialTicks, float skyDarken, float blockLightRedFlicker, float skyLight, int pixelX, int pixelY, Vector3f colors) {
+    @Intrinsic(displace = true)
+    public void astrological$adjustLightmapColors(ClientLevel level, float partialTicks, float skyDarken, float blockLightRedFlicker, float skyLight, int pixelX, int pixelY, Vector3f colors) {
         if (AstrologicalJsonReader.customEndLighting) {
             //float light = Math.min(10, pixelX);
             //IForgeDimensionSpecialEffects.super.adjustLightmapColors(level, partialTicks, skyDarken, blockLightRedFlicker, skyLight, pixelX, pixelY, colors.add(new Vector3f(0.07F*light, -0.07F*light, 0.01F*light)).min(new Vector3f(1, 1, 1)).max(new Vector3f(0.01f, 0.01f, 0.02f)));

--- a/src/main/resources/mixins.astrological.json
+++ b/src/main/resources/mixins.astrological.json
@@ -16,9 +16,12 @@
     "RenderTypeMixin"
   ],
   "client": [
-    "DimensionSpecialEffectsMixin",
+    "EndEffectsMixin",
     "DimensionTypeMixin"
   ],
   "server": [
-  ]
+  ],
+  "mixinextras": {
+    "minVersion": "0.5.3"
+  }
 }


### PR DESCRIPTION
@Apothicon02
Based on #17 
Closes #14, #11, #7 (but you should still merge #17 with this for parity)
- Rewrites most of the mod's mixin overwrites to be significantly more mod-compatible 
- Updates MixinExtras to 0.5.3

@BluSpring thanks for doing most of the legwork :)
> I highly recommend backporting this to 1.20.1 too... It should be fairly trivial to do so